### PR TITLE
Support tags as refs when invoked

### DIFF
--- a/params.ts
+++ b/params.ts
@@ -29,13 +29,13 @@ function getBranchName(): string {
     return branchName
   }
 
-  const regex = /refs\/heads\/(.*)/
+  const regex = /refs\/(heads|tags)\/(.*)/
   const ref = github.context.ref
   let result = regex.exec(ref);
-  if (!result) {
+  if (!result || result.length < 3) {
     throw new Error(`Failed to parse GitHub ref: ${ref}`)
   }
-  return result[1]
+  return result[2]
 }
 
 function getRepoName(): string {


### PR DESCRIPTION
This updates `getBranchName` to also allow parsing out the tag name when the current ref is a tag instead of a head to avoid this breaking whenever this is invoked on a tag.

![image](https://user-images.githubusercontent.com/6113675/212052751-582ca50c-8c42-4e5f-be74-910780f46b3b.png)