### PR TITLE
feat: send PR commit SHA

### DIFF
--- a/ApiClient.ts
+++ b/ApiClient.ts
@@ -15,6 +15,7 @@ export type UploadRequest = {
   repoName?: string
   pullRequestId?: string
   branch?: string,
+  commitSha?: string,
   env?: { [key: string]: string },
   agent: string,
   androidApiLevel?: number,

--- a/index.ts
+++ b/index.ts
@@ -51,6 +51,7 @@ const run = async () => {
     mappingFile,
     workspaceFolder,
     branchName,
+    commitSha,
     repoOwner,
     repoName,
     pullRequestId,
@@ -74,6 +75,7 @@ const run = async () => {
   const request: UploadRequest = {
     benchmarkName: name,
     branch: branchName,
+    commitSha: commitSha,
     repoOwner: repoOwner,
     repoName: repoName,
     pullRequestId: pullRequestId,

--- a/params.ts
+++ b/params.ts
@@ -11,6 +11,7 @@ export type Params = {
   mappingFile: string | null,
   workspaceFolder: string | null,
   branchName: string
+  commitSha?: string
   repoName: string
   repoOwner: string
   pullRequestId?: string,
@@ -36,6 +37,10 @@ function getBranchName(): string {
     throw new Error(`Failed to parse GitHub ref: ${ref}`)
   }
   return result[2]
+}
+
+function getCommitSha(): string | undefined {
+  return github.context.payload.pull_request?.head.sha
 }
 
 function getRepoName(): string {
@@ -103,9 +108,10 @@ export async function getParameters(): Promise<Params> {
     }, env)
 
   const branchName = getBranchName()
-  const repoOwner = getRepoOwner();
-  const repoName = getRepoName();
+  const commitSha = getCommitSha()
+  const repoOwner = getRepoOwner()
+  const repoName = getRepoName()
   const pullRequestId = getPullRequestId()
   const androidApiLevel = getAndroidApiLevel(androidApiLevelString)
-  return { apiUrl, name, apiKey, appFilePath, mappingFile, workspaceFolder, branchName, repoOwner, repoName, pullRequestId, env, async, androidApiLevel }
+  return { apiUrl, name, apiKey, appFilePath, mappingFile, workspaceFolder, branchName, commitSha, repoOwner, repoName, pullRequestId, env, async, androidApiLevel }
 }


### PR DESCRIPTION
This action will send the commit SHA that started the workflow to Maestro Cloud. This will ensure that GitHub Checks can update the correct commit.