### PR TITLE
Update action.yml to set name as not required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
   name:
     description: 'Name of the version of the uploaded app'
-    required: true
+    required: false
   app-file:
     description: 'The app file to upload to Maestro Cloud'
     required: true


### PR DESCRIPTION
This PR sets the required property on the `name` parameter to false in the `action.yml`

I have the VSCode [Github Actions Extension](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions) installed, it shows that I need to add the parameter 'name' but this is not true. 

<img width="612" alt="image" src="https://github.com/mobile-dev-inc/action-maestro-cloud/assets/877327/14f76b09-47a1-4bee-bd72-b3e08d5b54c2">

From checking the [params.ts](https://github.com/mobile-dev-inc/action-maestro-cloud/blob/main/params.ts#LL103C1-L103C1) file I think we can set required to false in the `action.yml`.

