### PR TITLE
Update README with output variable types

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,3 +255,25 @@ In order to access these variables you can use the following approach:
     echo "Upload Status: ${{ steps.upload.outputs.MAESTRO_CLOUD_UPLOAD_STATUS }}"
     echo "App Binary ID:: ${{ steps.upload.outputs.MAESTRO_CLOUD_APP_BINARY_ID }}"
 ```
+
+## Output types 
+
+- `MAESTRO_CLOUD_UPLOAD_STATUS`
+
+  Any of the following values:
+  ```
+  PENDING
+  RUNNING
+  SUCCESS
+  ERROR
+  CANCELED
+  WARNING
+  ```
+
+- `MAESTRO_CLOUD_FLOW_RESULTS`
+
+   An array of objects with at least `name`, `status`, and `errors` fields.
+   ```json
+   [{"name":"my-first-flow","status":"SUCCESS","errors":[]},{"name":"my-second-flow","status":"SUCCESS","errors":[]},{"name":"my-cancelled-flow","status":"CANCELED","errors":[],"cancellationReason":"INFRA_ERROR"}]
+   ```
+


### PR DESCRIPTION
The Maestro GH action returns variables that contain information about the results of the run which can be very useful in CI. These variables are noted in the README, but little information is given as to what those variables will actually contain. This means devs need to run fake CI runs, which take time and money, to see the type of output they're going to get. 

This PR simply clarifies what type the output variables will be, for those types which are not simply strings, hopefully saving devs time in debugging GH Actions workflows.