### PR TITLE
Use existing API URL

### DIFF
--- a/params.ts
+++ b/params.ts
@@ -121,7 +121,7 @@ export async function getParameters(): Promise<Params> {
   const apiUrl =
     core.getInput('api-url', { required: false }) ||
     (projectId
-      ? `https://api.app.robintest.com/v2/project/${projectId}`
+      ? `https://api.copilot.mobile.dev/v2/project/${projectId}`
       : 'https://api.mobile.dev')
   const name = core.getInput('name', { required: false }) || getInferredName()
   const apiKey = core.getInput('api-key', { required: true })


### PR DESCRIPTION
Whilst DNS doesn't resolve the new name, revert the API endpoint change from #45 