### PR TITLE
Make flow fail if not successful

### DIFF
--- a/StatusPoller.ts
+++ b/StatusPoller.ts
@@ -111,7 +111,7 @@ export default class StatusPoller {
         core.setOutput('MAESTRO_CLOUD_UPLOAD_STATUS', status)
         core.setOutput('MAESTRO_CLOUD_FLOW_RESULTS', flows)
 
-        if (status === UploadStatus.ERROR) {
+        if (status !== UploadStatus.SUCCESS) {
           const resultStr = getFailedFlowsCountStr(flows)
           console.log('')
           this.markFailed(resultStr)


### PR DESCRIPTION
This PR mitigates #28. 
At this point of the flow, every result that is not `SUCCESS` is a sign of failure or incomplete test run. 
With the original implementation, issues will be printed in the log, but the GH result will still be success. 

We have been using this in production for a few weeks now and it's worked as expected. 
