### PR TITLE
Fix Cannot use --format with --async error in async mode

### DIFF
--- a/.github/workflows/validate-local.yml
+++ b/.github/workflows/validate-local.yml
@@ -65,21 +65,11 @@ jobs:
           echo "MAESTRO_CLOUD_UPLOAD_STATUS=${{ steps.android.outputs.MAESTRO_CLOUD_UPLOAD_STATUS }}"
           echo "MAESTRO_CLOUD_FLOW_RESULTS=${{ steps.android.outputs.MAESTRO_CLOUD_FLOW_RESULTS }}"
 
-      # Exercises the async path. The CLI rejects --format with --async
-      # (CloudInteractor.kt:104), so this fails fast if run-cloud.sh ever
-      # regresses to passing --format unconditionally.
-      - name: Run Android async
-        uses: ./
-        with:
-          api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
-          project-id: proj_01jawvd2y2f4c9bzxwvs4dqqha
-          app-binary-id: ${{ steps.android.outputs.MAESTRO_CLOUD_APP_BINARY_ID }}
-          workspace: samples
-          include-tags: advanced
-          async: true
-          maestro-cli-version: ${{ inputs.maestro-cli-version }}
-
-      - name: Run Android with chained binary-id and multiline env
+      # Chained step doubles as the async smoke test: app-binary-id reuse,
+      # multiline env, device knobs, AND --async path. The CLI rejects --format
+      # with --async (CloudInteractor.kt:104), so this fails fast if
+      # run-cloud.sh ever regresses to passing --format unconditionally.
+      - name: Run Android async with chained binary-id and multiline env
         uses: ./
         with:
           api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
@@ -89,6 +79,7 @@ jobs:
           include-tags: advanced
           device-model: pixel_6
           device-os: android-34
+          async: true
           maestro-cli-version: ${{ inputs.maestro-cli-version }}
           env: |
             USERNAME=test_user

--- a/.github/workflows/validate-local.yml
+++ b/.github/workflows/validate-local.yml
@@ -110,7 +110,9 @@ jobs:
           echo "MAESTRO_CLOUD_UPLOAD_STATUS=${{ steps.ios.outputs.MAESTRO_CLOUD_UPLOAD_STATUS }}"
           echo "MAESTRO_CLOUD_FLOW_RESULTS=${{ steps.ios.outputs.MAESTRO_CLOUD_FLOW_RESULTS }}"
 
-      - name: Run iOS with chained binary-id
+      # Async on the iOS side too — covers the async path on both platforms
+      # without an extra upload.
+      - name: Run iOS async with chained binary-id
         uses: ./
         with:
           api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
@@ -121,4 +123,5 @@ jobs:
           device-model: iPhone-11
           device-os: iOS-18-2
           timeout: 180
+          async: true
           maestro-cli-version: ${{ inputs.maestro-cli-version }}

--- a/.github/workflows/validate-local.yml
+++ b/.github/workflows/validate-local.yml
@@ -65,6 +65,20 @@ jobs:
           echo "MAESTRO_CLOUD_UPLOAD_STATUS=${{ steps.android.outputs.MAESTRO_CLOUD_UPLOAD_STATUS }}"
           echo "MAESTRO_CLOUD_FLOW_RESULTS=${{ steps.android.outputs.MAESTRO_CLOUD_FLOW_RESULTS }}"
 
+      # Exercises the async path. The CLI rejects --format with --async
+      # (CloudInteractor.kt:104), so this fails fast if run-cloud.sh ever
+      # regresses to passing --format unconditionally.
+      - name: Run Android async
+        uses: ./
+        with:
+          api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
+          project-id: proj_01jawvd2y2f4c9bzxwvs4dqqha
+          app-binary-id: ${{ steps.android.outputs.MAESTRO_CLOUD_APP_BINARY_ID }}
+          workspace: samples
+          include-tags: advanced
+          async: true
+          maestro-cli-version: ${{ inputs.maestro-cli-version }}
+
       - name: Run Android with chained binary-id and multiline env
         uses: ./
         with:

--- a/__tests__/run-cloud.bats
+++ b/__tests__/run-cloud.bats
@@ -232,12 +232,24 @@ assert_args_contain() {
 
 # CloudInteractor.kt:104 rejects --format with --async ("Cannot use --format
 # with --async"), so neither --format nor --output may be passed in async mode.
-@test "omits --format and --output when MDEV_ASYNC=true" {
+# Also asserts no stray "true" token leaks into argv — a previous attempt used
+# ${MDEV_ASYNC:-...} which expands to the variable's value ("true") when set,
+# which the CLI then parses as the --flows positional path.
+@test "omits --format and --output when MDEV_ASYNC=true with no stray tokens" {
   export MDEV_ASYNC="true"
   run_script
   assert_success
   ! grep -q -- "--format" "$FAKE_MAESTRO_ARGS_FILE"
   ! grep -q -- "--output" "$FAKE_MAESTRO_ARGS_FILE"
+  # Argv should still terminate cleanly with --flows <workspace>.
+  local args
+  args="$(recorded_args)"
+  [[ "$args" == *"--flows flows" ]] || {
+    echo "Expected argv to end with '--flows flows', got: $args"
+    return 1
+  }
+  # No bare 'true' token should appear (only --async, which is a flag).
+  ! grep -qE '(^| )true( |$)' "$FAKE_MAESTRO_ARGS_FILE"
 }
 
 # NOTE: @actions/core.setOutput uses GitHub's heredoc framing in $GITHUB_OUTPUT

--- a/__tests__/run-cloud.bats
+++ b/__tests__/run-cloud.bats
@@ -223,11 +223,21 @@ assert_args_contain() {
   assert_failure 1
 }
 
-@test "passes --format junit and --output to the CLI" {
+@test "passes --format junit and --output to the CLI in sync mode" {
   run_script
   assert_success
   assert_args_contain "--format junit"
   assert_args_contain "--output"
+}
+
+# CloudInteractor.kt:104 rejects --format with --async ("Cannot use --format
+# with --async"), so neither --format nor --output may be passed in async mode.
+@test "omits --format and --output when MDEV_ASYNC=true" {
+  export MDEV_ASYNC="true"
+  run_script
+  assert_success
+  ! grep -q -- "--format" "$FAKE_MAESTRO_ARGS_FILE"
+  ! grep -q -- "--output" "$FAKE_MAESTRO_ARGS_FILE"
 }
 
 # NOTE: @actions/core.setOutput uses GitHub's heredoc framing in $GITHUB_OUTPUT

--- a/scripts/run-cloud.sh
+++ b/scripts/run-cloud.sh
@@ -13,8 +13,10 @@ if [ -n "$MDEV_ENV" ]; then
   done <<< "$MDEV_ENV"
 fi
 
-# JUnit XML is produced unconditionally so we can reconstruct
+# JUnit XML is produced in sync mode so we can reconstruct
 # MAESTRO_CLOUD_FLOW_RESULTS. The CLI doesn't expose a JSON format.
+# In async mode --format/--output are omitted: the CLI rejects --format with
+# --async (CloudInteractor.kt:104) since there are no results at upload time.
 # Explicit template (no `-t`) so mktemp behaves the same on BSD (macOS) and GNU.
 JUNIT_FILE=$(mktemp "${TMPDIR:-/tmp}/maestro-junit.XXXXXX") || { echo "::error::failed to create temp junit file"; exit 1; }
 
@@ -40,8 +42,8 @@ CLOUD_COMMAND=(maestro cloud
   ${MDEV_ASYNC:+--async}
   ${MDEV_ANDROID_API_LEVEL:+--android-api-level "$MDEV_ANDROID_API_LEVEL"}
   ${MDEV_IOS_VERSION:+--ios-version "$MDEV_IOS_VERSION"}
-  --format junit
-  --output "$JUNIT_FILE"
+  ${MDEV_ASYNC:---format junit}
+  ${MDEV_ASYNC:---output "$JUNIT_FILE"}
   "${env_args[@]+"${env_args[@]}"}"
   --flows "${MDEV_WORKSPACE:-.maestro}"
 )

--- a/scripts/run-cloud.sh
+++ b/scripts/run-cloud.sh
@@ -20,6 +20,15 @@ fi
 # Explicit template (no `-t`) so mktemp behaves the same on BSD (macOS) and GNU.
 JUNIT_FILE=$(mktemp "${TMPDIR:-/tmp}/maestro-junit.XXXXXX") || { echo "::error::failed to create temp junit file"; exit 1; }
 
+# Built before CLOUD_COMMAND so the array can splice it cleanly. We can't use
+# ${MDEV_ASYNC:-...} inline because that substitutes MDEV_ASYNC's *value*
+# ("true") when set — leaking a stray positional that the CLI parses as the
+# flows path. An explicit array keeps the expansion behavior unambiguous.
+format_args=()
+if [ -z "$MDEV_ASYNC" ]; then
+  format_args=(--format junit --output "$JUNIT_FILE")
+fi
+
 CLOUD_COMMAND=(maestro cloud
   --apiKey "$MDEV_API_KEY"
   --project-id "$MDEV_PROJECT_ID"
@@ -42,8 +51,7 @@ CLOUD_COMMAND=(maestro cloud
   ${MDEV_ASYNC:+--async}
   ${MDEV_ANDROID_API_LEVEL:+--android-api-level "$MDEV_ANDROID_API_LEVEL"}
   ${MDEV_IOS_VERSION:+--ios-version "$MDEV_IOS_VERSION"}
-  ${MDEV_ASYNC:---format junit}
-  ${MDEV_ASYNC:---output "$JUNIT_FILE"}
+  "${format_args[@]+"${format_args[@]}"}"
   "${env_args[@]+"${env_args[@]}"}"
   --flows "${MDEV_WORKSPACE:-.maestro}"
 )


### PR DESCRIPTION
## Summary

  - v3 hardcoded --format junit --output ... in run-cloud.sh, which the Maestro CLI rejects when combined with --async (CloudInteractor.kt:104).
  - Gate both flags on !MDEV_ASYNC so async runs no longer error. Sync mode is unchanged.

  ## Test plan

  - [x] bats __tests__/run-cloud.bats — 29/29 pass, including new test asserting --format/--output are omitted when MDEV_ASYNC=true.
  - [x] run validate action